### PR TITLE
Reach style menu sloping, now with sharper text

### DIFF
--- a/css/reach.css
+++ b/css/reach.css
@@ -23,28 +23,30 @@
     -webkit-font-smoothing: antialiased;
 }
 #browser-buttons {
-    width: 650px;
-    height: 28px;
+    width: 1300px;
+    height: 56px;
     position: absolute;
-    top: 115px;
+    top: 120px;
     right: 100px;
+    transform: scale3d(0.5,0.5,0.5) translatex(50%) translatey(-50%);
 }
 #network-toggle {
     display: none;
 }
 #refresh img {
     margin: 0;
-    height: 28px;
-    width: 28px;
+    height: 56px;
+    width: 56px;
 }
 #direct-connect {
     position: absolute;
     color: #fff;
     top: 20px;
     right: 20px;
-    font-size: 22px;
+    font-size: 44px;
     opacity: 0.85;
     z-index: 2;
+    transform: scale3d(0.5,0.5,0.5);
 }
 #load-more {
     position: absolute;
@@ -72,11 +74,11 @@
     float: right;
     color: #fff;
     top: 115px;
-    font-size: 18px;
+    font-size: 36px;
     opacity: 0.85;
     z-index: 2;
-    margin: 0 15px;
-    max-width: 200px;
+    margin: 0 30px;
+    max-width: 400px;
     box-sizing: border-box;
     -webkit-transition: 0.4s;
     -moz-transition: 0.4s;
@@ -102,7 +104,7 @@
     opacity: 0.8;
     z-index: 10;
     color: #fff;
-	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #menu {
     position: absolute;
@@ -129,12 +131,13 @@
     top: 60px;
     left: 100px;
     font-weight: 700;
-    font-size: 68px;
+    font-size: 136px;
     color: #fff;
     opacity: 0.85;
     background: -webkit-linear-gradient(#fff, #999);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #browser {
     position: absolute;
@@ -151,7 +154,8 @@
 }
 #browser.regular .server {
     height: 100px;
-    font-size: 20px;
+    font-size: 40px;
+    transform: scale3d(0.5,1.0,0.5) translatex(-50%);
 }
 #browser.condensed .server {
     height: 70px;
@@ -162,11 +166,11 @@
     font-size: 20px;
 }
 #browser .server {
-    width: 1074px;
+    width: 2148px;
     box-sizing: border-box;
     font-weight: 300;
     color: rgba(255, 255, 255, 0.85);
-    border-left: 3px solid rgba(255, 255, 255, 0);
+    border-left: 6px solid rgba(255, 255, 255, 0);
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
@@ -174,54 +178,74 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+#browser.regular .flag {
+    position: relative;
+    top: 0px;
+    display: inline-block;
+    vertical-align: top;
+    max-width:60px;
+    max-height:46px;
+}
 .selection input[type="text"] {
     border: none;
     background: transparent;
-    font-size: 22px;
+    font-size: 44px;
     color: rgba(255, 255, 255, 0.85);
     outline: none;
     text-align: center;
     box-sizing: border-box;
     width: 100%;
-    height: 34px;
+    height: 68px;
 }
 .regular .server .thumb,
 .regular .server .info {
     display: inline-block;
-    width: 590px;
-    height: 100px;
+    width: 1180px;
+    height: 200px;
     box-sizing: border-box;
     white-space: nowrap;
-    padding: 10px 0px !important;
+    padding: 20px 0px !important;
     vertical-align: top;
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .regular .server .thumb {
     text-align: center;
-    width: 240px;
+    width: 480px;
 }
 .regular .server .players {
     display: inline-block;
-    width: 240px;
-    height: 100px;
+    width: 480px;
+    height: 200px;
     text-align: right;
     font-weight: 300;
-    font-size: 38px;
+    font-size: 76px;
     box-sizing: border-box;
     white-space: nowrap;
-    padding: 30px 40px !important;
+    padding: 60px 80px !important;
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%)
 }
 .regular .server .settings {
     padding: 0 0px;
     font-weight: 300;
-    font-size: 25px;
+    font-size: 50px;
     text-align: left;
     vertical-align: center;
     width: 600px;
 }
 #browser.regular .server .thumb img {
-    border: 1px solid rgba(255, 255, 255, 0.9);
-    width: 210px;
-    height: 79px;
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    width: 420px;
+    height: 158px;
+}
+.regular .server.passworded .thumb:before{
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    width: 420px;
+    height: 158px;
+    left: 28px;
+    top: 20px;
+}
+.regular .elversion {
+    font-size: 30px;
 }
 .condensed .server .thumb,
 .condensed .server .info {
@@ -232,6 +256,7 @@
     white-space: nowrap;
     padding: 5px 0px !important;
     vertical-align: top;
+    transform: scale3d(1.0,0.5,1.0);
 }
 .condensed .server .thumb {
     text-align: center;
@@ -247,6 +272,7 @@
     box-sizing: border-box;
     white-space: nowrap;
     padding: 15px 30px !important;
+    transform: scale3d(1.0,0.5,1.0);
 }
 .condensed .server .settings {
     padding: 0 0px;
@@ -312,7 +338,11 @@
     padding-top: 5px;
     overflow-x: hidden;
 }
-
+#browser.regular .name
+{
+    position: relative;
+    padding-top: 24px;
+}
 .regular .name,
 .regular .settings,
 .condensed .name,
@@ -359,6 +389,7 @@ audio {
 #serverbrowser,
 #credits {
     top: -720px;
+    transform:translate(3.75%) rotate3D(0,1,0,1deg);
 }
 .animated {
     -webkit-transition: 400ms;
@@ -486,13 +517,13 @@ audio {
     background: -webkit-linear-gradient(#fff, #999);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
-	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #subtitle {
     top: 390px;
     font-size: 44px;
     font-weight: 300;
-	transform: scale3d(0.5,0.5,0.5) translatex(-50%);
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%);
 }
 #line1,
 #line2,
@@ -553,28 +584,29 @@ audio {
     text-align: center;
     display: table-cell;
     width: 540px;
-    padding: 7px 0px 0px 0px;
+    padding: 14px 0px 0px 0px;
     box-sizing: border-box;
     height: 40px;
-	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .options-select2 .selection .input {
     text-align: center;
     display: table-cell;
-    width: 270px;
+    width: 560px;
     padding: 0;
     box-sizing: border-box;
     height: 40px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .options-select2 .selection .label,
 #select .selection .label {
     text-align: left;
     display: table-cell;
     width: 800px;
-    padding: 7px 10px 0px 10px;
+    padding: 14px 20px 0px 14px;
     box-sizing: border-box;
     height: 40px;
-	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .options-select2 .selection {
     font-weight: 300;
@@ -588,7 +620,7 @@ audio {
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
-	transform: scale3d(0.5,1.0,0.5) translatex(-33%);
+    transform: scale3d(0.5,1.0,0.5) translatex(-33%);
 }
 .options-select2 {
     position: absolute;
@@ -661,7 +693,7 @@ audio {
     padding: 14px 20px 0px 20px;
     box-sizing: border-box;
     height: 80px;
-	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
+    transform: scale3d(1.0,0.5,1.0) translatey(-33%);
 }
 
 .music-select .selection,
@@ -699,7 +731,7 @@ audio {
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
-	transform: scale3d(0.5,1.0,0.5) translatex(-33%);
+    transform: scale3d(0.5,1.0,0.5) translatex(-33%);
 }
 .map-select .selection,
 .music-select .selection,
@@ -720,7 +752,7 @@ audio {
     opacity: 0.5;
     box-sizing: border-box;
     padding: 0;
-	transform: scale3d(2.0,1.0,2.0) translatey(-15%) translatex(-15%);
+    transform: scale3d(2.0,1.0,2.0) translatey(-15%) translatex(-15%);
 }
 .left {
     background-image: url('../img/left.png');
@@ -741,7 +773,7 @@ audio {
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
-	transform: scale3d(0.5,1.0,0.5) translatex(-50%);
+    transform: scale3d(0.5,1.0,0.5) translatex(-50%);
 }
 .select-main .selection {
     font-size: 44px;
@@ -754,7 +786,7 @@ audio {
     padding: 20px 20px;
     box-sizing: border-box;
     height: 80px;
-	transform: scale3d(1.0,0.5,1.0) translatey(-50%);
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .select-main .selection .label,
 #select .selection .label {
@@ -764,7 +796,7 @@ audio {
     padding: 20px 20px;
     box-sizing: border-box;
     height: 80px;
-	transform: scale3d(1.0,0.5,1.0) translatey(-50%);
+    transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .selection:hover,
 .server:hover,
@@ -806,7 +838,7 @@ audio {
     width: 600px;
     height: 1024px;
     overflow-y: scroll;
-	transform: scale3d(0.5,0.5,0.5) translatex(83%) translatey(-60%);
+    transform: scale3d(0.5,0.5,0.5) translatex(83%) translatey(-60%);
 }
 #lobby .top td.info {
     background: rgba(0, 0, 0, 0.5);
@@ -942,7 +974,7 @@ audio {
     opacity: 0.75;
     display: none;
     z-index: 999;
-	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(50%);
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(50%);
 }
 .options-menu {
     background: -moz-linear-gradient(top, rgba(0, 38, 64, 0.9) 0%, rgba(0, 0, 0, 0.9) 100%);
@@ -976,7 +1008,7 @@ audio {
     background: -webkit-linear-gradient(#fff, #999);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
-	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
+    transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #dot {
     position: absolute;
@@ -990,10 +1022,10 @@ audio {
 }
 #version {
     right: 5px;
-	bottom: 5px;
-	font-size: 28px;
-	opacity: 0.5;
-	font-family: "Conduit ITC";
-	font-weight: 300;
-	transform: scale3d(0.5,0.5,0.5) translatex(50%) translatey(50%);
+    bottom: 5px;
+    font-size: 28px;
+    opacity: 0.5;
+    font-family: "Conduit ITC";
+    font-weight: 300;
+    transform: scale3d(0.5,0.5,0.5) translatex(50%) translatey(50%);
 }

--- a/css/reach.css
+++ b/css/reach.css
@@ -386,10 +386,12 @@ audio {
     top:-720px;
     transform:translate(3.75%) rotate3D(0,1,0,1deg);
 }
-#serverbrowser,
-#credits {
+#serverbrowser{
     top: -720px;
     transform:translate(3.75%) rotate3D(0,1,0,1deg);
+}
+#credits {
+    top: -720px;
 }
 .animated {
     -webkit-transition: 400ms;
@@ -428,23 +430,24 @@ audio {
     right: 120px;
 }
 #credits table {
-    width: 680px;
+    width: 1360px;
     position: absolute;
     left: 300px;
     top: 200px;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #credits table td.label {
-    width: 540px;
+    width: 1080px;
     text-align: left;
-    font-size: 24px;
+    font-size: 48px;
     color: #fff;
     opacity: 0.9;
     vertical-align: top;
 }
 #credits table td.name {
-    width: 540px;
+    width: 1080px;
     text-align: right;
-    font-size: 24px;
+    font-size: 48px;
     color: #fff;
     opacity: 0.9;
     vertical-align: top;
@@ -486,14 +489,16 @@ audio {
 #music-game,
 #type-name-options {
     top: 320px;
-    font-size: 26px;
+    font-size: 52px;
     opacity: 0.85;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%);
 }
 #map-info-options,
 #type-info-options {
     top: 380px;
-    font-size: 16px;
+    font-size: 32px;
     opacity: 0.7;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%);
 }
 #gametype-icon {
     position: absolute;
@@ -893,6 +898,7 @@ audio {
     overflow: hidden;
     opacity: 0.9;
     background: rgba(0, 0, 0, 0.45);
+	transform: rotate3D(0,1,0,-1deg)
 }
 #player-rank-display {
     position: absolute;
@@ -904,12 +910,12 @@ audio {
 }
 #player-name {
     display: block;
-    font-size: 22px;
-    margin: 10px 0;
+    font-size: 44px;
+    margin: 20px 0;
 }
 #player-level-display {
     display: block;
-    font-size: 18px;
+    font-size: 36px;
     opacity: 0.8;
     margin: 0;
 }
@@ -920,6 +926,7 @@ audio {
     width: 536px;
     height: 100px;
     color: #fff;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #player-kd-chart {
     position: relative;
@@ -950,9 +957,10 @@ audio {
     top: 70px;
     text-align: center;
     z-index: 2;
-    font-size: 38px;
+    font-size: 76px;
     color: #fff;
     width: 100%;
+	transform: scale3d(0.5,0.5,0.5) translatey(-50%);
 }
 #player-armor {
     position: absolute;

--- a/css/reach.css
+++ b/css/reach.css
@@ -651,6 +651,9 @@ audio {
 #customgame ::-webkit-scrollbar {
     width: 4px;
 }
+#lobby-container::-webkit-scrollbar{
+	width: 0px;
+}
 .map-select2,
 .type-select2 {
     position: absolute;

--- a/css/reach.css
+++ b/css/reach.css
@@ -98,10 +98,11 @@
     position: absolute;
     top: 20px;
     left: 20px;
-    font-size: 22px;
+    font-size: 44px;
     opacity: 0.8;
     z-index: 10;
     color: #fff;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #menu {
     position: absolute;
@@ -118,6 +119,10 @@
     -moz-transform-origin: top left;
     transform-origin: top left;
     box-sizing: border-box;
+    -webkit-perspective: 150px;
+    -webkit-perspective-origin: 50% 50%;
+    perspective: 150px;
+    perspective-origin: 50% 50%;
 }
 #browser-title {
     position: absolute;
@@ -347,7 +352,10 @@ audio {
     width: 1280px;
     height: 720px;
 }
-#main,
+#main{
+    top:-720px;
+    transform:translate(3.75%) rotate3D(0,1,0,1deg);
+}
 #serverbrowser,
 #credits {
     top: -720px;
@@ -363,10 +371,12 @@ audio {
 #customgame {
     top: -720px;
     left: 0;
+    transform:translate(3.75%) rotate3D(0,1,0,1deg);
 }
 #main2 {
     top: 0px;
     left: 0;
+    transform:translate(3.75%) rotate3D(0,1,0,1deg);
 }
 #map-thumb,
 #map-thumb-options {
@@ -461,15 +471,17 @@ audio {
 #title {
     top: 300px;
     font-weight: 700;
-    font-size: 68px;
+    font-size: 136px;
     background: -webkit-linear-gradient(#fff, #999);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #subtitle {
     top: 390px;
-    font-size: 22px;
+    font-size: 44px;
     font-weight: 300;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%);
 }
 #line1,
 #line2,
@@ -527,10 +539,11 @@ audio {
 #select .selection .value {
     text-align: center;
     display: table-cell;
-    width: 270px;
+    width: 540px;
     padding: 7px 0px 0px 0px;
     box-sizing: border-box;
     height: 40px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
 }
 .options-select2 .selection .input {
     text-align: center;
@@ -544,23 +557,25 @@ audio {
 #select .selection .label {
     text-align: left;
     display: table-cell;
-    width: 400px;
+    width: 800px;
     padding: 7px 10px 0px 10px;
     box-sizing: border-box;
     height: 40px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
 }
 .options-select2 .selection {
     font-weight: 300;
-    font-size: 23px;
+    font-size: 46px;
     color: rgba(255, 255, 255, 0.85);
-    width: 670px;
+    width: 1340px;
     height: 35px;
-    border-left: 3px solid rgba(255, 255, 255, 0);
+    border-left: 6px solid rgba(255, 255, 255, 0);
     box-sizing: border-box;
-    line-height: 20px;
+    line-height: 40px;
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
+	transform: scale3d(0.5,1.0,0.5) translatex(-33%);
 }
 .options-select2 {
     position: absolute;
@@ -606,10 +621,11 @@ audio {
 .options-select .selection .label {
     text-align: left;
     display: table-cell;
-    width: 260px;
-    padding: 7px 10px 0px 10px;
+    width: 520px;
+    padding: 14px 20px 0px 20px;
     box-sizing: border-box;
-    height: 40px;
+    height: 80px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-33%);
 }
 .map-select .selection,
 .map-select2 .selection,
@@ -617,21 +633,22 @@ audio {
 .type-select2 .selection,
 .options-select .selection {
     font-weight: 300;
-    font-size: 23px;
+    font-size: 46px;
     color: rgba(255, 255, 255, 0.85);
-    width: 260px;
+    width: 520px;
     height: 35px;
-    border-left: 3px solid rgba(255, 255, 255, 0);
+    border-left: 6px solid rgba(255, 255, 255, 0);
     box-sizing: border-box;
     line-height: 20px;
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
+	transform: scale3d(0.5,1.0,0.5) translatex(-33%);
 }
 .map-select .selection,
 .type-select .selection,
 .options-select .selection {
-    background: url('../img/right.png') no-repeat 232px 8px/18px auto;
+    background: url('../img/right.png') no-repeat 464px 8px/18px auto;
 }
 .left,
 .right {
@@ -646,6 +663,7 @@ audio {
     opacity: 0.5;
     box-sizing: border-box;
     padding: 0;
+	transform: scale3d(2.0,1.0,2.0) translatey(-15%) translatex(-15%);
 }
 .left {
     background-image: url('../img/left.png');
@@ -656,37 +674,40 @@ audio {
 #select .selection,
 .select-main .selection {
     font-weight: 300;
-    font-size: 19px;
+    font-size: 38px;
     color: rgba(255, 255, 255, 0.85);
-    width: 450px;
+    width: 900px;
     height: 40px;
-    border-left: 3px solid rgba(255, 255, 255, 0);
+    border-left: 6px solid rgba(255, 255, 255, 0);
     box-sizing: border-box;
-    line-height: 20px;
+    line-height: 40px;
     -webkit-transition: 0.5s;
     -moz-transition: 0.5s;
     transition: 0.5s;
+	transform: scale3d(0.5,1.0,0.5) translatex(-50%);
 }
 .select-main .selection {
-    font-size: 22px;
+    font-size: 44px;
 }
 .select-main .selection .value,
 #select .selection .value {
     text-align: right;
     display: table-cell;
-    width: 225px;
-    padding: 10px 10px;
+    width: 450px;
+    padding: 20px 20px;
     box-sizing: border-box;
-    height: 40px;
+    height: 80px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .select-main .selection .label,
 #select .selection .label {
     text-align: left;
     display: table-cell;
-    width: 225px;
-    padding: 10px 10px;
+    width: 450px;
+    padding: 20px 20px;
     box-sizing: border-box;
-    height: 40px;
+    height: 80px;
+	transform: scale3d(1.0,0.5,1.0) translatey(-50%);
 }
 .selection:hover,
 .server:hover,
@@ -717,25 +738,26 @@ audio {
     z-index: 2;
 }
 #lobby {
-    width: 300px;
+    width: 600px;
     border-collapse: separate;
-    border-spacing: 0px 2px;
+    border-spacing: 0px 4px;
 }
 #lobby-container {
     position: absolute;
-    top: 50px;
-    right: 100px;
-    width: 300px;
-    height: 612px;
+    top: 100px;
+    right: 200px;
+    width: 600px;
+    height: 1024px;
     overflow-y: scroll;
+	transform: scale3d(0.5,0.5,0.5) translatex(83%) translatey(-60%);
 }
 #lobby .top td.info {
     background: rgba(0, 0, 0, 0.5);
     font-weight: 300;
-    font-size: 18px;
-    width: 300px;
-    height: 30px;
-    padding: 5px 10px;
+    font-size: 36px;
+    width: 600px;
+    height: 60px;
+    padding: 10px 20px;
     box-sizing: border-box;
     color: #fff;
 }
@@ -746,27 +768,27 @@ audio {
 }
 #lobby td {
     box-sizing: border-box;
-    margin-bottom: 3px;
-    height: 30px;
+    margin-bottom: 6px;
+    height: 60px;
     color: #fff;
     cursor: pointer;
 }
 #lobby td.name {
     font-weight: 300;
-    font-size: 18px;
-    width: 250px;
-    padding: 0px 20px 2px 20px;
-    background: no-repeat 160px 4px/58px 26px;
+    font-size: 36px;
+    width: 1000px;
+    padding: 4px 40px 4px 40px;
+    background: no-repeat 320px 8px/116px 52px;
 }
 #lobby td.rank {
-    width: 50px;
-    padding: 0px 10px 0px 10px;
+    width: 100px;
+    padding: 0px 20px 0px 20px;
     text-align: center;
     background: rgba(0, 0, 0, 0.15);
 }
 #lobby td.rank img {
-    max-width: 28px;
-    max-height: 28px;
+    max-width: 56px;
+    max-height: 56px;
     margin-top: 0px;
     opacity: 0.9;
     box-sizing: border-box;
@@ -859,10 +881,11 @@ audio {
 #back {
     left: 20px;
     bottom: 20px;
-    font-size: 18px;
+    font-size: 36px;
     opacity: 0.75;
     display: none;
     z-index: 999;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(50%);
 }
 .options-menu {
     background: -moz-linear-gradient(top, rgba(0, 38, 64, 0.9) 0%, rgba(0, 0, 0, 0.9) 100%);
@@ -889,13 +912,14 @@ audio {
     top: 60px;
     left: 150px;
     font-weight: 700;
-    font-size: 48px;
+    font-size: 96px;
     color: #fff;
     opacity: 0.9;
     z-index: 4;
     background: -webkit-linear-gradient(#fff, #999);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+	transform: scale3d(0.5,0.5,0.5) translatex(-50%) translatey(-50%);
 }
 #dot {
     position: absolute;
@@ -906,4 +930,13 @@ audio {
     height: 90px;
     z-index: 3;
     opacity: 0.67;
+}
+#version {
+    right: 5px;
+	bottom: 5px;
+	font-size: 28px;
+	opacity: 0.5;
+	font-family: "Conduit ITC";
+	font-weight: 300;
+	transform: scale3d(0.5,0.5,0.5) translatex(50%) translatey(50%);
 }

--- a/css/reach.css
+++ b/css/reach.css
@@ -843,7 +843,7 @@ audio {
     top: 100px;
     right: 200px;
     width: 600px;
-    height: 1024px;
+    height: 1088px;
     overflow-y: scroll;
     transform: scale3d(0.5,0.5,0.5) translatex(83%) translatey(-60%);
 }


### PR DESCRIPTION
Now the text is sharped by doubling the font size and then shrinking them in half in 3d, this seems to be the only way to get webkit to sharpen the text when there are two transforms (The rotation and the scale from 1280x720). Because of this any extra text that is added will need to be doubled in size and then shrunk to prevent it from looking blurry.

Main menu text sharp at 2560x1440
![highresmenutext](https://cloud.githubusercontent.com/assets/13316727/8746521/65feac68-2ccd-11e5-9afd-b052db124692.jpg)

Server browser text sharp and rotated at 2560x1440
![highresserverbrowser](https://cloud.githubusercontent.com/assets/13316727/8746529/76b23b92-2ccd-11e5-8ead-80923e0520a7.jpg)
